### PR TITLE
Updated installation options

### DIFF
--- a/domains/misc/http.badssl.com/.gitignore
+++ b/domains/misc/http.badssl.com/.gitignore
@@ -1,0 +1,1 @@
+badssl-root.pem


### PR DESCRIPTION
Two new ways to run your local badssl:

- Run "make install", which will do everything to your local machine besides fiddling with nginx.conf
- Run via docker, where you can get a fully running and configured Docker image in two easy commands