### PR TITLE
Add http password site

### DIFF
--- a/common/common.conf
+++ b/common/common.conf
@@ -36,6 +36,11 @@ location /mixed/ {
   try_files $uri $uri/ =404;
 }
 
+location /password {
+  root /var/www/badssl/common;
+  try_files $uri $uri/ =404;
+}
+
 location /certs/ {
   root /var/www/badssl/common;
   try_files $uri $uri/ =404;

--- a/common/password/index.html
+++ b/common/password/index.html
@@ -1,0 +1,110 @@
+<!doctype html>
+<html>
+<head>
+  <title>http password</title>
+  <link rel="shortcut icon" href="/icons/favicon-red.ico"/>
+  <link rel="apple-touch-icon" href="/icons/icon-red.png"/>
+  <style>
+    html, body {
+      background: red;
+
+      margin: 0;
+      padding: 0;
+
+      height: 100%;
+      display: -webkit-flexbox;
+      display: -ms-flexbox;
+      display: -webkit-flex;
+      display: flex;
+      -webkit-align-items: center;
+      align-items: center;
+      -webkit-justify-content: center;
+      justify-content: center;
+    }
+    input {
+      background: red;
+      border: 0;
+      color: white;
+      text-align: center;
+      font-family: "Source Code Pro", Monaco, Consolas, "Courier New", monospace, Impact;
+      font-size: 5em;
+      font-size: 10vw;
+      font-weight: bold;
+      outline: none;
+      text-shadow:
+        0 0 20px rgba(255, 255, 255, 0.5),
+        0 0 40px rgba(255, 255, 255, 0.5),
+        0 0 60px rgba(255, 255, 255, 0.5);
+    }
+    ::-moz-placeholder {
+      color: white;
+      font-family: monospace;
+      font-family: "Source Code Pro", Monaco, Consolas, "Courier New", monospace, Impact;
+      font-size: 5em;
+      font-size: 10vw;
+      font-weight: bold;
+      opacity: 1;
+      text-shadow:
+        0 0 20px rgba(255, 255, 255, 0.5),
+        0 0 40px rgba(255, 255, 255, 0.5),
+        0 0 60px rgba(255, 255, 255, 0.5);
+    }
+    :-ms-input-placeholder {
+      color: white;
+      font-family: "Source Code Pro", Monaco, Consolas, "Courier New", monospace, Impact;
+      font-size: 5em;
+      font-size: 10vw;
+      font-weight: bold;
+      opacity: 1;
+      text-shadow:
+        0 0 20px rgba(255, 255, 255, 0.5),
+        0 0 40px rgba(255, 255, 255, 0.5),
+        0 0 60px rgba(255, 255, 255, 0.5);
+    }
+    ::-ms-input-placeholder {
+      color: white;
+      font-family: "Source Code Pro", Monaco, Consolas, "Courier New", monospace, Impact;
+      font-size: 5em;
+      font-size: 10vw;
+      font-weight: bold;
+      opacity: 1;
+      text-shadow:
+        0 0 20px rgba(255, 255, 255, 0.5),
+        0 0 40px rgba(255, 255, 255, 0.5),
+        0 0 60px rgba(255, 255, 255, 0.5);
+    }
+    ::-webkit-input-placeholder {
+      color: white;
+      font-family: "Source Code Pro", Monaco, Consolas, "Courier New", monospace, Impact;
+      font-size: 5em;
+      font-size: 10vw;
+      font-weight: bold;
+      opacity: 1;
+      text-shadow:
+        0 0 20px rgba(255, 255, 255, 0.5),
+        0 0 40px rgba(255, 255, 255, 0.5),
+        0 0 60px rgba(255, 255, 255, 0.5);
+    }
+    .footer {
+      background: rgba(0, 0, 0, 0.25);
+      
+      position: fixed;
+      width: 80vw;
+      bottom: 0;
+      left: 0;
+      padding: 2vh 10vw;
+
+      font-family: Helvetica, Tahoma, sans-serif;
+      text-align: center;
+      color: white;
+      font-size: 3vw;
+    }
+  </style>
+</head>
+<body>
+  <form>
+    <input type="password" name="password" placeholder="http password" autofocus>
+  </form>
+  <div class="footer">This site has a password field on an insecure (HTTP) page.</div>
+</body>
+</html>

--- a/domains/misc/badssl.com/index.html
+++ b/domains/misc/badssl.com/index.html
@@ -213,6 +213,7 @@
     <a href="https://very.badssl.com/" class="more bad comic-sans">very</a>
     <a href="https://rc4-md5.badssl.com/" class="more neutral">rc4-md5</a>
     <a href="http://http.badssl.com/" class="more neutral">http</a>
+    <a href="http://http.badssl.com/password/" class="more bad">http/password</a>
     <a href="https://mixed.badssl.com/mixed/image" class="more dubious no-interstitial">mixed/image</a>
     <a href="https://mixed.badssl.com/mixed/form" class="more dubious no-interstitial">mixed/form</a>
     <a href="https://mixed.badssl.com/mixed/script" class="more bad no-interstitial">mixed/script</a>


### PR DESCRIPTION
Should be visible at: http://http.badssl.com/password/

Screenshot: http://i.imgur.com/PGUrh1W.png

As per this upcoming Firefox change: https://twitter.com/rlbarnes/status/656554266744586240

P.S.: The public site has been very very slow lately

P.P.S.: Styling placeholder text is the literal worst