### PR TITLE
New domain: https-everywhere

### DIFF
--- a/domains/misc/https-everywhere.badssl.com-http/index.html
+++ b/domains/misc/https-everywhere.badssl.com-http/index.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html>
+<head>
+  <title>https-everywhere.badssl.com</title>
+  <link rel="shortcut icon" href="/icons/favicon-red.ico"/>
+  <link rel="apple-touch-icon" href="/icons/icon-red.png"/>
+  <style>
+    html, body {
+      background: #A44;
+
+      margin: 0;
+      padding: 0;
+
+      height: 100%;
+      display: -webkit-flexbox;
+      display: -ms-flexbox;
+      display: -webkit-flex;
+      display: flex;
+      -webkit-align-items: center;
+      align-items: center;
+      -webkit-justify-content: center;
+      justify-content: center;
+    }
+    h1 {
+      color: white;
+      text-align: center;
+      font-family: "Source Code Pro", Monaco, Consolas, "Courier New", monospace, Impact;
+      font-size: 5em;
+      font-size: 9vw;
+      text-shadow:
+        0 0 20px rgba(255, 255, 255, 0.5),
+        0 0 40px rgba(255, 255, 255, 0.5),
+        0 0 60px rgba(255, 255, 255, 0.5);
+    }
+	.footer {
+      background: rgba(0, 0, 0, 0.25);
+      
+      position: fixed;
+      width: 80vw;
+      bottom: 0;
+      left: 0;
+      padding: 2vh 10vw;
+
+      font-family: Helvetica, Tahoma, sans-serif;
+      text-align: center;
+      color: white;
+      font-size: 3vw;
+    }
+	#http-vs-https {
+      height: 1.5em;
+      vertical-align: middle;
+    }
+	a {
+      color: rgb(255, 202, 202);
+    }
+  </style>
+</head>
+<body>
+    <h1>https-everywhere.<br>badssl.com</h1>
+	<div class="footer">HTTPS-Everywhere does not work or is not enabled.<br>Included in: <a href="https://www.eff.org/https-everywhere">HTTPS-Everywhere</a> v[unknown]</div>
+</body>
+</html>

--- a/domains/misc/https-everywhere.badssl.com-http/redirect-test/status.svg
+++ b/domains/misc/https-everywhere.badssl.com-http/redirect-test/status.svg
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="120mm"
+   height="16mm"
+   viewBox="0 0 425.19685 56.692915"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="test.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="3.959798"
+     inkscape:cx="173.86508"
+     inkscape:cy="71.33982"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="2484"
+     inkscape:window-height="1395"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4419" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-56.458405,-314.7236)"
+     style="opacity:1">
+    <g
+       style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="text4470">
+      <path
+         d="m 118.48915,326.12765 0,26.775 3.5625,0 0,-12.2625 14.1,0 0,12.2625 3.5625,0 0,-26.775 -3.5625,0 0,11.5125 -14.1,0 0,-11.5125 -3.5625,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:37.5px;font-family:'Helvetica Neue';-inkscape-font-specification:'Helvetica Neue';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path4139" />
+      <path
+         d="m 161.07626,333.96515 3.375,0 q -0.075,-2.2125 -0.8625,-3.7875 -0.75,-1.6125 -2.1,-2.6625 -1.3125,-1.05 -3.075,-1.5375 -1.7625,-0.4875 -3.825,-0.4875 -1.8375,0 -3.6,0.4875 -1.725,0.45 -3.1125,1.425 -1.35,0.9375 -2.175,2.4375 -0.825,1.4625 -0.825,3.4875 0,1.8375 0.7125,3.075 0.75,1.2 1.95,1.9875 1.2375,0.75 2.775,1.2375 1.5375,0.45 3.1125,0.825 1.6125,0.3375 3.15,0.675 1.5375,0.3375 2.7375,0.9 1.2375,0.525 1.95,1.3875 0.75,0.8625 0.75,2.25 0,1.4625 -0.6,2.4 -0.6,0.9375 -1.575,1.5 -0.975,0.525 -2.2125,0.75 -1.2,0.225 -2.4,0.225 -1.5,0 -2.925,-0.375 -1.425,-0.375 -2.5125,-1.1625 -1.05,-0.7875 -1.725,-1.9875 -0.6375,-1.2375 -0.6375,-2.925 l -3.375,0 q 0,2.4375 0.8625,4.2375 0.9,1.7625 2.4,2.925 1.5375,1.125 3.525,1.6875 2.025,0.5625 4.275,0.5625 1.8375,0 3.675,-0.45 1.875,-0.4125 3.375,-1.35 1.5,-0.975 2.4375,-2.475 0.975,-1.5375 0.975,-3.675 0,-1.9875 -0.75,-3.3 -0.7125,-1.3125 -1.95,-2.175 -1.2,-0.8625 -2.7375,-1.35 -1.5375,-0.525 -3.15,-0.9 -1.575,-0.375 -3.1125,-0.675 -1.5375,-0.3375 -2.775,-0.825 -1.2,-0.4875 -1.95,-1.2375 -0.7125,-0.7875 -0.7125,-2.025 0,-1.3125 0.4875,-2.175 0.525,-0.9 1.35,-1.425 0.8625,-0.525 1.95,-0.75 1.0875,-0.225 2.2125,-0.225 2.775,0 4.5375,1.3125 1.8,1.275 2.1,4.1625 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:37.5px;font-family:'Helvetica Neue';-inkscape-font-specification:'Helvetica Neue';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path4141" />
+      <path
+         d="m 175.98016,329.12765 0,23.775 3.5625,0 0,-23.775 8.925,0 0,-3 -21.4125,0 0,3 8.925,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:37.5px;font-family:'Helvetica Neue';-inkscape-font-specification:'Helvetica Neue';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path4143" />
+      <path
+         d="m 206.92587,333.96515 3.375,0 q -0.075,-2.2125 -0.8625,-3.7875 -0.75,-1.6125 -2.1,-2.6625 -1.3125,-1.05 -3.075,-1.5375 -1.7625,-0.4875 -3.825,-0.4875 -1.8375,0 -3.6,0.4875 -1.725,0.45 -3.1125,1.425 -1.35,0.9375 -2.175,2.4375 -0.825,1.4625 -0.825,3.4875 0,1.8375 0.7125,3.075 0.75,1.2 1.95,1.9875 1.2375,0.75 2.775,1.2375 1.5375,0.45 3.1125,0.825 1.6125,0.3375 3.15,0.675 1.5375,0.3375 2.7375,0.9 1.2375,0.525 1.95,1.3875 0.75,0.8625 0.75,2.25 0,1.4625 -0.6,2.4 -0.6,0.9375 -1.575,1.5 -0.975,0.525 -2.2125,0.75 -1.2,0.225 -2.4,0.225 -1.5,0 -2.925,-0.375 -1.425,-0.375 -2.5125,-1.1625 -1.05,-0.7875 -1.725,-1.9875 -0.6375,-1.2375 -0.6375,-2.925 l -3.375,0 q 0,2.4375 0.8625,4.2375 0.9,1.7625 2.4,2.925 1.5375,1.125 3.525,1.6875 2.025,0.5625 4.275,0.5625 1.8375,0 3.675,-0.45 1.875,-0.4125 3.375,-1.35 1.5,-0.975 2.4375,-2.475 0.975,-1.5375 0.975,-3.675 0,-1.9875 -0.75,-3.3 -0.7125,-1.3125 -1.95,-2.175 -1.2,-0.8625 -2.7375,-1.35 -1.5375,-0.525 -3.15,-0.9 -1.575,-0.375 -3.1125,-0.675 -1.5375,-0.3375 -2.775,-0.825 -1.2,-0.4875 -1.95,-1.2375 -0.7125,-0.7875 -0.7125,-2.025 0,-1.3125 0.4875,-2.175 0.525,-0.9 1.35,-1.425 0.8625,-0.525 1.95,-0.75 1.0875,-0.225 2.2125,-0.225 2.775,0 4.5375,1.3125 1.8,1.275 2.1,4.1625 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:37.5px;font-family:'Helvetica Neue';-inkscape-font-specification:'Helvetica Neue';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path4145" />
+      <path
+         d="m 229.00516,330.02765 0,-3.9 -3.1875,0 0,3.9 3.1875,0 z m -3.1875,3.4875 0,19.3875 3.1875,0 0,-19.3875 -3.1875,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:37.5px;font-family:'Helvetica Neue';-inkscape-font-specification:'Helvetica Neue';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path4147" />
+      <path
+         d="m 235.92977,346.79015 -3.1875,0 q 0.075,1.8 0.75,3.075 0.675,1.2375 1.8,2.025 1.125,0.75 2.5875,1.0875 1.4625,0.3375 3.075,0.3375 1.4625,0 2.925,-0.3 1.5,-0.2625 2.6625,-0.975 1.2,-0.7125 1.9125,-1.875 0.75,-1.1625 0.75,-2.925 0,-1.3875 -0.5625,-2.325 -0.525,-0.9375 -1.425,-1.5375 -0.8625,-0.6375 -2.025,-1.0125 -1.125,-0.375 -2.325,-0.6375 -1.125,-0.2625 -2.25,-0.4875 -1.125,-0.2625 -2.025,-0.6 -0.9,-0.375 -1.5,-0.9 -0.5625,-0.5625 -0.5625,-1.3875 0,-0.75 0.375,-1.2 0.375,-0.4875 0.975,-0.75 0.6,-0.3 1.3125,-0.4125 0.75,-0.1125 1.4625,-0.1125 0.7875,0 1.5375,0.1875 0.7875,0.15 1.425,0.525 0.6375,0.375 1.05,1.0125 0.4125,0.6 0.4875,1.5375 l 3.1875,0 q -0.1125,-1.7625 -0.75,-2.925 -0.6375,-1.2 -1.725,-1.875 -1.05,-0.7125 -2.4375,-0.975 -1.3875,-0.3 -3.0375,-0.3 -1.275,0 -2.5875,0.3375 -1.275,0.3 -2.325,0.975 -1.0125,0.6375 -1.6875,1.6875 -0.6375,1.05 -0.6375,2.5125 0,1.875 0.9375,2.925 0.9375,1.05 2.325,1.65 1.425,0.5625 3.075,0.9 1.65,0.3 3.0375,0.7125 1.425,0.375 2.3625,1.0125 0.9375,0.6375 0.9375,1.875 0,0.9 -0.45,1.5 -0.45,0.5625 -1.1625,0.8625 -0.675,0.3 -1.5,0.4125 -0.825,0.1125 -1.575,0.1125 -0.975,0 -1.9125,-0.1875 -0.9,-0.1875 -1.65,-0.6 -0.7125,-0.45 -1.1625,-1.1625 -0.45,-0.75 -0.4875,-1.8 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:37.5px;font-family:'Helvetica Neue';-inkscape-font-specification:'Helvetica Neue';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path4149" />
+      <path
+         d="m 263.05692,333.51515 0,19.3875 3.1875,0 0,-10.95 q 0,-1.3125 0.3375,-2.4 0.375,-1.125 1.0875,-1.95 0.7125,-0.825 1.7625,-1.275 1.0875,-0.45 2.55,-0.45 1.8375,0 2.8875,1.05 1.05,1.05 1.05,2.85 l 0,13.125 3.1875,0 0,-12.75 q 0,-1.575 -0.3375,-2.85 -0.3,-1.3125 -1.0875,-2.25 -0.7875,-0.9375 -2.0625,-1.4625 -1.275,-0.525 -3.1875,-0.525 -4.3125,0 -6.3,3.525 l -0.075,0 0,-3.075 -3,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:37.5px;font-family:'Helvetica Neue';-inkscape-font-specification:'Helvetica Neue';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path4151" />
+      <path
+         d="m 286.25594,343.22765 q 0,-1.7625 0.45,-3.1125 0.4875,-1.3875 1.3125,-2.325 0.825,-0.9375 1.9125,-1.425 1.125,-0.4875 2.3625,-0.4875 1.2375,0 2.325,0.4875 1.125,0.4875 1.95,1.425 0.825,0.9375 1.275,2.325 0.4875,1.35 0.4875,3.1125 0,1.7625 -0.4875,3.15 -0.45,1.35 -1.275,2.2875 -0.825,0.9 -1.95,1.3875 -1.0875,0.4875 -2.325,0.4875 -1.2375,0 -2.3625,-0.4875 -1.0875,-0.4875 -1.9125,-1.3875 -0.825,-0.9375 -1.3125,-2.2875 -0.45,-1.3875 -0.45,-3.15 z m -3.375,0 q 0,2.1375 0.6,3.975 0.6,1.8375 1.8,3.225 1.2,1.35 2.9625,2.1375 1.7625,0.75 4.05,0.75 2.325,0 4.05,-0.75 1.7625,-0.7875 2.9625,-2.1375 1.2,-1.3875 1.8,-3.225 0.6,-1.8375 0.6,-3.975 0,-2.1375 -0.6,-3.975 -0.6,-1.875 -1.8,-3.225 -1.2,-1.3875 -2.9625,-2.175 -1.725,-0.7875 -4.05,-0.7875 -2.2875,0 -4.05,0.7875 -1.7625,0.7875 -2.9625,2.175 -1.2,1.35 -1.8,3.225 -0.6,1.8375 -0.6,3.975 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:37.5px;font-family:'Helvetica Neue';-inkscape-font-specification:'Helvetica Neue';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path4153" />
+      <path
+         d="m 309.81591,333.51515 0,-5.8125 -3.1875,0 0,5.8125 -3.3,0 0,2.8125 3.3,0 0,12.3375 q 0,1.35 0.2625,2.175 0.2625,0.825 0.7875,1.275 0.5625,0.45 1.425,0.6375 0.9,0.15 2.1375,0.15 l 2.4375,0 0,-2.8125 -1.4625,0 q -0.75,0 -1.2375,-0.0375 -0.45,-0.075 -0.7125,-0.2625 -0.2625,-0.1875 -0.375,-0.525 -0.075,-0.3375 -0.075,-0.9 l 0,-12.0375 3.8625,0 0,-2.8125 -3.8625,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:37.5px;font-family:'Helvetica Neue';-inkscape-font-specification:'Helvetica Neue';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path4155" />
+      <path
+         d="m 346.85653,352.90265 6.1875,-19.3875 -3.3,0 -4.35,15.8625 -0.075,0 -4.05,-15.8625 -3.4875,0 -3.9,15.8625 -0.075,0 -4.3875,-15.8625 -3.525,0 6.225,19.3875 3.45,0 3.9,-15.4125 0.075,0 3.9375,15.4125 3.375,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:37.5px;font-family:'Helvetica Neue';-inkscape-font-specification:'Helvetica Neue';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path4157" />
+      <path
+         d="m 358.3995,343.22765 q 0,-1.7625 0.45,-3.1125 0.4875,-1.3875 1.3125,-2.325 0.825,-0.9375 1.9125,-1.425 1.125,-0.4875 2.3625,-0.4875 1.2375,0 2.325,0.4875 1.125,0.4875 1.95,1.425 0.825,0.9375 1.275,2.325 0.4875,1.35 0.4875,3.1125 0,1.7625 -0.4875,3.15 -0.45,1.35 -1.275,2.2875 -0.825,0.9 -1.95,1.3875 -1.0875,0.4875 -2.325,0.4875 -1.2375,0 -2.3625,-0.4875 -1.0875,-0.4875 -1.9125,-1.3875 -0.825,-0.9375 -1.3125,-2.2875 -0.45,-1.3875 -0.45,-3.15 z m -3.375,0 q 0,2.1375 0.6,3.975 0.6,1.8375 1.8,3.225 1.2,1.35 2.9625,2.1375 1.7625,0.75 4.05,0.75 2.325,0 4.05,-0.75 1.7625,-0.7875 2.9625,-2.1375 1.2,-1.3875 1.8,-3.225 0.6,-1.8375 0.6,-3.975 0,-2.1375 -0.6,-3.975 -0.6,-1.875 -1.8,-3.225 -1.2,-1.3875 -2.9625,-2.175 -1.725,-0.7875 -4.05,-0.7875 -2.2875,0 -4.05,0.7875 -1.7625,0.7875 -2.9625,2.175 -1.2,1.35 -1.8,3.225 -0.6,1.8375 -0.6,3.975 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:37.5px;font-family:'Helvetica Neue';-inkscape-font-specification:'Helvetica Neue';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path4159" />
+      <path
+         d="m 377.42196,333.51515 0,19.3875 3.1875,0 0,-8.625 q 0,-1.875 0.375,-3.3 0.375,-1.4625 1.2,-2.475 0.825,-1.0125 2.175,-1.5375 1.35,-0.525 3.2625,-0.525 l 0,-3.375 q -2.5875,-0.075 -4.275,1.05 -1.6875,1.125 -2.85,3.4875 l -0.075,0 0,-4.0875 -3,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:37.5px;font-family:'Helvetica Neue';-inkscape-font-specification:'Helvetica Neue';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path4161" />
+      <path
+         d="m 390.24637,326.12765 0,26.775 3.1875,0 0,-7.35 3,-2.775 6.6375,10.125 4.05,0 -8.25,-12.3375 7.6875,-7.05 -4.275,0 -8.85,8.475 0,-15.8625 -3.1875,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:37.5px;font-family:'Helvetica Neue';-inkscape-font-specification:'Helvetica Neue';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path4163" />
+      <path
+         d="m 412.9163,330.02765 0,-3.9 -3.1875,0 0,3.9 3.1875,0 z m -3.1875,3.4875 0,19.3875 3.1875,0 0,-19.3875 -3.1875,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:37.5px;font-family:'Helvetica Neue';-inkscape-font-specification:'Helvetica Neue';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path4165" />
+      <path
+         d="m 417.89091,333.51515 0,19.3875 3.1875,0 0,-10.95 q 0,-1.3125 0.3375,-2.4 0.375,-1.125 1.0875,-1.95 0.7125,-0.825 1.7625,-1.275 1.0875,-0.45 2.55,-0.45 1.8375,0 2.8875,1.05 1.05,1.05 1.05,2.85 l 0,13.125 3.1875,0 0,-12.75 q 0,-1.575 -0.3375,-2.85 -0.3,-1.3125 -1.0875,-2.25 -0.7875,-0.9375 -2.0625,-1.4625 -1.275,-0.525 -3.1875,-0.525 -4.3125,0 -6.3,3.525 l -0.075,0 0,-3.075 -3,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:37.5px;font-family:'Helvetica Neue';-inkscape-font-specification:'Helvetica Neue';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path4167" />
+      <path
+         d="m 455.48993,351.25265 0,-17.7375 -3,0 0,2.775 -0.0375,0 q -0.8625,-1.6125 -2.4,-2.4 -1.5375,-0.825 -3.375,-0.825 -2.5125,0 -4.2375,0.975 -1.725,0.9375 -2.775,2.4375 -1.05,1.4625 -1.5,3.3 -0.45,1.8 -0.45,3.525 0,1.9875 0.525,3.7875 0.5625,1.7625 1.65,3.1125 1.0875,1.3125 2.7,2.1 1.6125,0.7875 3.7875,0.7875 1.875,0 3.525,-0.825 1.6875,-0.8625 2.5125,-2.6625 l 0.075,0 0,1.275 q 0,1.6125 -0.3375,2.9625 -0.3,1.35 -1.0125,2.2875 -0.7125,0.975 -1.8,1.5 -1.0875,0.5625 -2.6625,0.5625 -0.7875,0 -1.65,-0.1875 -0.8625,-0.15 -1.6125,-0.525 -0.7125,-0.375 -1.2375,-0.975 -0.4875,-0.6 -0.525,-1.4625 l -3.1875,0 q 0.075,1.575 0.825,2.6625 0.75,1.0875 1.875,1.7625 1.1625,0.675 2.55,0.975 1.425,0.3 2.775,0.3 4.65,0 6.825,-2.3625 2.175,-2.3625 2.175,-7.125 z m -8.925,-0.9375 q -1.575,0 -2.625,-0.6375 -1.05,-0.675 -1.6875,-1.725 -0.6375,-1.0875 -0.9,-2.4 -0.2625,-1.3125 -0.2625,-2.625 0,-1.3875 0.3,-2.6625 0.3375,-1.275 1.0125,-2.25 0.7125,-0.975 1.8,-1.5375 1.0875,-0.6 2.625,-0.6 1.5,0 2.55,0.6 1.05,0.6 1.6875,1.6125 0.675,0.975 0.975,2.2125 0.3,1.2375 0.3,2.5125 0,1.35 -0.3375,2.7 -0.3,1.35 -0.975,2.4375 -0.675,1.05 -1.8,1.725 -1.0875,0.6375 -2.6625,0.6375 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:37.5px;font-family:'Helvetica Neue';-inkscape-font-specification:'Helvetica Neue';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path4169" />
+      <path
+         d="m 460.93739,348.74015 0,4.1625 4.1625,0 0,-4.1625 -4.1625,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:37.5px;font-family:'Helvetica Neue';-inkscape-font-specification:'Helvetica Neue';text-align:start;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path4171" />
+    </g>
+    <g
+       style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="text3336">
+      <path
+         d="m 81.962669,341.07416 -2.539063,-10.2295 q -0.90332,-3.61328 -0.90332,-3.85742 0,-1.0498 0.561524,-1.75781 0.561523,-0.70801 1.147461,-0.70801 1.196289,0 2.954101,2.05078 1.757813,2.05078 4.199219,8.00782 0.976563,-0.75684 1.928711,-1.75782 l 2.709962,-2.7832 q 2.832031,-3.05176 3.491211,-3.71094 0.683594,-0.65918 1.5625,-0.65918 0.976563,0 1.68457,1.00098 0.708008,0.97656 0.708008,1.70898 l 0,0.19532 q -0.292969,0.0976 -0.537109,0.0976 -1.074219,0.14649 -1.31836,1.09863 -0.146484,0.41504 -0.341797,0.61036 -0.659179,0.51269 -1.660156,2.07519 l -2.075195,3.27149 q -1.5625,2.58789 -2.514649,3.90625 -0.732422,0.97656 -1.074219,1.61132 -0.317383,0.63477 -0.317383,1.44043 0,1.80665 1.049805,4.68751 1.049805,2.88085 2.685547,5.34668 1.049805,1.51367 1.049805,1.70898 l -0.146484,0.29297 q -0.195313,0.3418 -0.195313,0.61035 0,0.0732 0.09766,0.43945 -1.367187,0.75684 -1.489258,0.8545 -0.09766,0.0976 -0.09766,0.61035 l 0.04883,0.24414 q 0,0.19531 -0.219726,0.19531 -0.09766,0 -0.65918,-0.26855 -0.537109,-0.26856 -1.220703,-1.07422 -0.634766,-0.8545 -1.269532,-0.95215 -0.366211,-0.19531 -0.439453,-0.29297 -0.805664,-0.97656 -1.489258,-1.24512 -0.341797,-0.1709 -0.561523,-0.61035 l -2.661133,-4.54102 q -2.197266,1.87989 -5.200196,5.2002 -3.125,3.54004 -5.200196,5.44434 l 0,-0.70801 q -0.195312,-0.39063 -0.537109,-0.90332 -0.195313,-0.26856 -0.292969,-0.63477 -0.12207,-0.46386 -0.512695,-0.56152 -0.170899,0 -0.341797,-0.3418 -0.146484,-0.46386 -0.463867,-0.61035 -0.390625,-0.14648 -0.390625,-0.3418 0,-0.0488 0.09766,-0.46386 -0.146484,-0.29297 -0.146484,-0.43946 0,-0.63476 6.25,-7.69043 2.734375,-3.14941 4.589844,-5.5664 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:50.00000381px;font-family:'Helvetica Neue';-inkscape-font-specification:'Helvetica Neue';text-align:center;text-anchor:middle;fill:#ff0000;fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path4174" />
+    </g>
+  </g>
+</svg>

--- a/domains/misc/https-everywhere.badssl.com-https/index.html
+++ b/domains/misc/https-everywhere.badssl.com-https/index.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html>
+<head>
+  <title>https-everywhere.badssl.com</title>
+  <link rel="shortcut icon" href="/icons/favicon-green.ico"/>
+  <link rel="apple-touch-icon" href="/icons/icon-green.png"/>
+  <style>
+    html, body {
+      background: #484;
+
+      margin: 0;
+      padding: 0;
+
+      height: 100%;
+      display: -webkit-flexbox;
+      display: -ms-flexbox;
+      display: -webkit-flex;
+      display: flex;
+      -webkit-align-items: center;
+      align-items: center;
+      -webkit-justify-content: center;
+      justify-content: center;
+    }
+    h1 {
+      color: white;
+      text-align: center;
+      font-family: "Source Code Pro", Monaco, Consolas, "Courier New", monospace, Impact;
+      font-size: 5em;
+      font-size: 9vw;
+      text-shadow:
+        0 0 20px rgba(255, 255, 255, 0.5),
+        0 0 40px rgba(255, 255, 255, 0.5),
+        0 0 60px rgba(255, 255, 255, 0.5);
+    }
+    .footer {
+      background: rgba(0, 0, 0, 0.25);
+      
+      position: fixed;
+      width: 80vw;
+      bottom: 0;
+      left: 0;
+      padding: 2vh 10vw;
+
+      font-family: Helvetica, Tahoma, sans-serif;
+      text-align: center;
+      color: white;
+      font-size: 3vw;
+    }
+    #http-vs-https {
+      height: 1.5em;
+      vertical-align: middle;
+    }
+	a {
+      color: rgb(211, 255, 202);
+    }
+  </style>
+</head>
+<body>
+    <h1>https-everywhere.<br>badssl.com</h1>
+    <div class="footer"><img id="http-vs-https" src="http://https-everywhere.badssl.com/redirect-test/status.svg" title="This is an image with an HTTP source location specified. If HTTPS-Everywhere is working and activated, the source should be rewritten to HTTPS. The image will vary depending on the outcome."><br>Included in: <a href="https://www.eff.org/https-everywhere">HTTPS-Everywhere</a> v[unknown]</div>
+</body>
+</html>

--- a/domains/misc/https-everywhere.badssl.com-https/redirect-test/status.svg
+++ b/domains/misc/https-everywhere.badssl.com-https/redirect-test/status.svg
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="100mm"
+   height="16mm"
+   viewBox="0 0 354.33071 56.692915"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="test.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="3.959798"
+     inkscape:cx="155.92948"
+     inkscape:cy="15.339825"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2484"
+     inkscape:window-height="1395"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4419" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-56.458405,-314.7236)"
+     style="opacity:1">
+    <g
+       style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#00ff00;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="text3336">
+      <path
+         d="m 78.178489,349.74115 q 2.246094,-5.12695 4.809571,-9.79004 2.587891,-4.6875 5.322266,-8.64258 3.222656,-4.63867 5.078125,-6.68945 1.196289,-1.31836 2.246094,-2.17285 0.610352,-0.48829 1.928711,-0.73243 3.198244,-0.58593 4.467774,-0.58593 0.56152,0 0.56152,0.39062 0,0.36621 -0.56152,0.87891 -4.882813,4.3457 -10.253907,12.42676 -5.34668,8.08105 -9.033204,17.16308 -1.391601,3.39356 -1.953125,4.17481 -0.537109,0.75683 -3.417969,0.75683 -1.879883,0 -2.368164,-0.36621 -0.463867,-0.36621 -1.708985,-2.31933 -2.148437,-3.24707 -4.614258,-5.85938 -1.293945,-1.36719 -1.293945,-2.09961 0,-1.02539 1.440429,-2.00195 1.44043,-1.00098 2.368165,-1.00098 1.293945,0 3.100586,1.46485 1.831055,1.44043 3.881836,5.00488 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:50.00000381px;font-family:'Helvetica Neue';-inkscape-font-specification:'Helvetica Neue';text-align:center;text-anchor:middle;fill:#00ff00;fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path4139" />
+    </g>
+    <g
+       style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="text4313">
+      <path
+         d="m 118.48915,326.12765 0,26.775 3.5625,0 0,-12.2625 14.1,0 0,12.2625 3.5625,0 0,-26.775 -3.5625,0 0,11.5125 -14.1,0 0,-11.5125 -3.5625,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:37.5px;font-family:'Helvetica Neue';-inkscape-font-specification:'Helvetica Neue';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path4142" />
+      <path
+         d="m 161.07626,333.96515 3.375,0 q -0.075,-2.2125 -0.8625,-3.7875 -0.75,-1.6125 -2.1,-2.6625 -1.3125,-1.05 -3.075,-1.5375 -1.7625,-0.4875 -3.825,-0.4875 -1.8375,0 -3.6,0.4875 -1.725,0.45 -3.1125,1.425 -1.35,0.9375 -2.175,2.4375 -0.825,1.4625 -0.825,3.4875 0,1.8375 0.7125,3.075 0.75,1.2 1.95,1.9875 1.2375,0.75 2.775,1.2375 1.5375,0.45 3.1125,0.825 1.6125,0.3375 3.15,0.675 1.5375,0.3375 2.7375,0.9 1.2375,0.525 1.95,1.3875 0.75,0.8625 0.75,2.25 0,1.4625 -0.6,2.4 -0.6,0.9375 -1.575,1.5 -0.975,0.525 -2.2125,0.75 -1.2,0.225 -2.4,0.225 -1.5,0 -2.925,-0.375 -1.425,-0.375 -2.5125,-1.1625 -1.05,-0.7875 -1.725,-1.9875 -0.6375,-1.2375 -0.6375,-2.925 l -3.375,0 q 0,2.4375 0.8625,4.2375 0.9,1.7625 2.4,2.925 1.5375,1.125 3.525,1.6875 2.025,0.5625 4.275,0.5625 1.8375,0 3.675,-0.45 1.875,-0.4125 3.375,-1.35 1.5,-0.975 2.4375,-2.475 0.975,-1.5375 0.975,-3.675 0,-1.9875 -0.75,-3.3 -0.7125,-1.3125 -1.95,-2.175 -1.2,-0.8625 -2.7375,-1.35 -1.5375,-0.525 -3.15,-0.9 -1.575,-0.375 -3.1125,-0.675 -1.5375,-0.3375 -2.775,-0.825 -1.2,-0.4875 -1.95,-1.2375 -0.7125,-0.7875 -0.7125,-2.025 0,-1.3125 0.4875,-2.175 0.525,-0.9 1.35,-1.425 0.8625,-0.525 1.95,-0.75 1.0875,-0.225 2.2125,-0.225 2.775,0 4.5375,1.3125 1.8,1.275 2.1,4.1625 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:37.5px;font-family:'Helvetica Neue';-inkscape-font-specification:'Helvetica Neue';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path4144" />
+      <path
+         d="m 175.98016,329.12765 0,23.775 3.5625,0 0,-23.775 8.925,0 0,-3 -21.4125,0 0,3 8.925,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:37.5px;font-family:'Helvetica Neue';-inkscape-font-specification:'Helvetica Neue';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path4146" />
+      <path
+         d="m 206.92587,333.96515 3.375,0 q -0.075,-2.2125 -0.8625,-3.7875 -0.75,-1.6125 -2.1,-2.6625 -1.3125,-1.05 -3.075,-1.5375 -1.7625,-0.4875 -3.825,-0.4875 -1.8375,0 -3.6,0.4875 -1.725,0.45 -3.1125,1.425 -1.35,0.9375 -2.175,2.4375 -0.825,1.4625 -0.825,3.4875 0,1.8375 0.7125,3.075 0.75,1.2 1.95,1.9875 1.2375,0.75 2.775,1.2375 1.5375,0.45 3.1125,0.825 1.6125,0.3375 3.15,0.675 1.5375,0.3375 2.7375,0.9 1.2375,0.525 1.95,1.3875 0.75,0.8625 0.75,2.25 0,1.4625 -0.6,2.4 -0.6,0.9375 -1.575,1.5 -0.975,0.525 -2.2125,0.75 -1.2,0.225 -2.4,0.225 -1.5,0 -2.925,-0.375 -1.425,-0.375 -2.5125,-1.1625 -1.05,-0.7875 -1.725,-1.9875 -0.6375,-1.2375 -0.6375,-2.925 l -3.375,0 q 0,2.4375 0.8625,4.2375 0.9,1.7625 2.4,2.925 1.5375,1.125 3.525,1.6875 2.025,0.5625 4.275,0.5625 1.8375,0 3.675,-0.45 1.875,-0.4125 3.375,-1.35 1.5,-0.975 2.4375,-2.475 0.975,-1.5375 0.975,-3.675 0,-1.9875 -0.75,-3.3 -0.7125,-1.3125 -1.95,-2.175 -1.2,-0.8625 -2.7375,-1.35 -1.5375,-0.525 -3.15,-0.9 -1.575,-0.375 -3.1125,-0.675 -1.5375,-0.3375 -2.775,-0.825 -1.2,-0.4875 -1.95,-1.2375 -0.7125,-0.7875 -0.7125,-2.025 0,-1.3125 0.4875,-2.175 0.525,-0.9 1.35,-1.425 0.8625,-0.525 1.95,-0.75 1.0875,-0.225 2.2125,-0.225 2.775,0 4.5375,1.3125 1.8,1.275 2.1,4.1625 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:37.5px;font-family:'Helvetica Neue';-inkscape-font-specification:'Helvetica Neue';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path4148" />
+      <path
+         d="m 229.00516,330.02765 0,-3.9 -3.1875,0 0,3.9 3.1875,0 z m -3.1875,3.4875 0,19.3875 3.1875,0 0,-19.3875 -3.1875,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:37.5px;font-family:'Helvetica Neue';-inkscape-font-specification:'Helvetica Neue';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path4150" />
+      <path
+         d="m 235.92977,346.79015 -3.1875,0 q 0.075,1.8 0.75,3.075 0.675,1.2375 1.8,2.025 1.125,0.75 2.5875,1.0875 1.4625,0.3375 3.075,0.3375 1.4625,0 2.925,-0.3 1.5,-0.2625 2.6625,-0.975 1.2,-0.7125 1.9125,-1.875 0.75,-1.1625 0.75,-2.925 0,-1.3875 -0.5625,-2.325 -0.525,-0.9375 -1.425,-1.5375 -0.8625,-0.6375 -2.025,-1.0125 -1.125,-0.375 -2.325,-0.6375 -1.125,-0.2625 -2.25,-0.4875 -1.125,-0.2625 -2.025,-0.6 -0.9,-0.375 -1.5,-0.9 -0.5625,-0.5625 -0.5625,-1.3875 0,-0.75 0.375,-1.2 0.375,-0.4875 0.975,-0.75 0.6,-0.3 1.3125,-0.4125 0.75,-0.1125 1.4625,-0.1125 0.7875,0 1.5375,0.1875 0.7875,0.15 1.425,0.525 0.6375,0.375 1.05,1.0125 0.4125,0.6 0.4875,1.5375 l 3.1875,0 q -0.1125,-1.7625 -0.75,-2.925 -0.6375,-1.2 -1.725,-1.875 -1.05,-0.7125 -2.4375,-0.975 -1.3875,-0.3 -3.0375,-0.3 -1.275,0 -2.5875,0.3375 -1.275,0.3 -2.325,0.975 -1.0125,0.6375 -1.6875,1.6875 -0.6375,1.05 -0.6375,2.5125 0,1.875 0.9375,2.925 0.9375,1.05 2.325,1.65 1.425,0.5625 3.075,0.9 1.65,0.3 3.0375,0.7125 1.425,0.375 2.3625,1.0125 0.9375,0.6375 0.9375,1.875 0,0.9 -0.45,1.5 -0.45,0.5625 -1.1625,0.8625 -0.675,0.3 -1.5,0.4125 -0.825,0.1125 -1.575,0.1125 -0.975,0 -1.9125,-0.1875 -0.9,-0.1875 -1.65,-0.6 -0.7125,-0.45 -1.1625,-1.1625 -0.45,-0.75 -0.4875,-1.8 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:37.5px;font-family:'Helvetica Neue';-inkscape-font-specification:'Helvetica Neue';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path4152" />
+      <path
+         d="m 282.25692,352.90265 6.1875,-19.3875 -3.3,0 -4.35,15.8625 -0.075,0 -4.05,-15.8625 -3.4875,0 -3.9,15.8625 -0.075,0 -4.3875,-15.8625 -3.525,0 6.225,19.3875 3.45,0 3.9,-15.4125 0.075,0 3.9375,15.4125 3.375,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:37.5px;font-family:'Helvetica Neue';-inkscape-font-specification:'Helvetica Neue';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path4154" />
+      <path
+         d="m 293.79989,343.22765 q 0,-1.7625 0.45,-3.1125 0.4875,-1.3875 1.3125,-2.325 0.825,-0.9375 1.9125,-1.425 1.125,-0.4875 2.3625,-0.4875 1.2375,0 2.325,0.4875 1.125,0.4875 1.95,1.425 0.825,0.9375 1.275,2.325 0.4875,1.35 0.4875,3.1125 0,1.7625 -0.4875,3.15 -0.45,1.35 -1.275,2.2875 -0.825,0.9 -1.95,1.3875 -1.0875,0.4875 -2.325,0.4875 -1.2375,0 -2.3625,-0.4875 -1.0875,-0.4875 -1.9125,-1.3875 -0.825,-0.9375 -1.3125,-2.2875 -0.45,-1.3875 -0.45,-3.15 z m -3.375,0 q 0,2.1375 0.6,3.975 0.6,1.8375 1.8,3.225 1.2,1.35 2.9625,2.1375 1.7625,0.75 4.05,0.75 2.325,0 4.05,-0.75 1.7625,-0.7875 2.9625,-2.1375 1.2,-1.3875 1.8,-3.225 0.6,-1.8375 0.6,-3.975 0,-2.1375 -0.6,-3.975 -0.6,-1.875 -1.8,-3.225 -1.2,-1.3875 -2.9625,-2.175 -1.725,-0.7875 -4.05,-0.7875 -2.2875,0 -4.05,0.7875 -1.7625,0.7875 -2.9625,2.175 -1.2,1.35 -1.8,3.225 -0.6,1.8375 -0.6,3.975 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:37.5px;font-family:'Helvetica Neue';-inkscape-font-specification:'Helvetica Neue';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path4156" />
+      <path
+         d="m 312.82235,333.51515 0,19.3875 3.1875,0 0,-8.625 q 0,-1.875 0.375,-3.3 0.375,-1.4625 1.2,-2.475 0.825,-1.0125 2.175,-1.5375 1.35,-0.525 3.2625,-0.525 l 0,-3.375 q -2.5875,-0.075 -4.275,1.05 -1.6875,1.125 -2.85,3.4875 l -0.075,0 0,-4.0875 -3,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:37.5px;font-family:'Helvetica Neue';-inkscape-font-specification:'Helvetica Neue';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path4158" />
+      <path
+         d="m 325.64677,326.12765 0,26.775 3.1875,0 0,-7.35 3,-2.775 6.6375,10.125 4.05,0 -8.25,-12.3375 7.6875,-7.05 -4.275,0 -8.85,8.475 0,-15.8625 -3.1875,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:37.5px;font-family:'Helvetica Neue';-inkscape-font-specification:'Helvetica Neue';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path4160" />
+      <path
+         d="m 348.31669,330.02765 0,-3.9 -3.1875,0 0,3.9 3.1875,0 z m -3.1875,3.4875 0,19.3875 3.1875,0 0,-19.3875 -3.1875,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:37.5px;font-family:'Helvetica Neue';-inkscape-font-specification:'Helvetica Neue';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path4162" />
+      <path
+         d="m 353.2913,333.51515 0,19.3875 3.1875,0 0,-10.95 q 0,-1.3125 0.3375,-2.4 0.375,-1.125 1.0875,-1.95 0.7125,-0.825 1.7625,-1.275 1.0875,-0.45 2.55,-0.45 1.8375,0 2.8875,1.05 1.05,1.05 1.05,2.85 l 0,13.125 3.1875,0 0,-12.75 q 0,-1.575 -0.3375,-2.85 -0.3,-1.3125 -1.0875,-2.25 -0.7875,-0.9375 -2.0625,-1.4625 -1.275,-0.525 -3.1875,-0.525 -4.3125,0 -6.3,3.525 l -0.075,0 0,-3.075 -3,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:37.5px;font-family:'Helvetica Neue';-inkscape-font-specification:'Helvetica Neue';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path4164" />
+      <path
+         d="m 390.89032,351.25265 0,-17.7375 -3,0 0,2.775 -0.0375,0 q -0.8625,-1.6125 -2.4,-2.4 -1.5375,-0.825 -3.375,-0.825 -2.5125,0 -4.2375,0.975 -1.725,0.9375 -2.775,2.4375 -1.05,1.4625 -1.5,3.3 -0.45,1.8 -0.45,3.525 0,1.9875 0.525,3.7875 0.5625,1.7625 1.65,3.1125 1.0875,1.3125 2.7,2.1 1.6125,0.7875 3.7875,0.7875 1.875,0 3.525,-0.825 1.6875,-0.8625 2.5125,-2.6625 l 0.075,0 0,1.275 q 0,1.6125 -0.3375,2.9625 -0.3,1.35 -1.0125,2.2875 -0.7125,0.975 -1.8,1.5 -1.0875,0.5625 -2.6625,0.5625 -0.7875,0 -1.65,-0.1875 -0.8625,-0.15 -1.6125,-0.525 -0.7125,-0.375 -1.2375,-0.975 -0.4875,-0.6 -0.525,-1.4625 l -3.1875,0 q 0.075,1.575 0.825,2.6625 0.75,1.0875 1.875,1.7625 1.1625,0.675 2.55,0.975 1.425,0.3 2.775,0.3 4.65,0 6.825,-2.3625 2.175,-2.3625 2.175,-7.125 z m -8.925,-0.9375 q -1.575,0 -2.625,-0.6375 -1.05,-0.675 -1.6875,-1.725 -0.6375,-1.0875 -0.9,-2.4 -0.2625,-1.3125 -0.2625,-2.625 0,-1.3875 0.3,-2.6625 0.3375,-1.275 1.0125,-2.25 0.7125,-0.975 1.8,-1.5375 1.0875,-0.6 2.625,-0.6 1.5,0 2.55,0.6 1.05,0.6 1.6875,1.6125 0.675,0.975 0.975,2.2125 0.3,1.2375 0.3,2.5125 0,1.35 -0.3375,2.7 -0.3,1.35 -0.975,2.4375 -0.675,1.05 -1.8,1.725 -1.0875,0.6375 -2.6625,0.6375 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:37.5px;font-family:'Helvetica Neue';-inkscape-font-specification:'Helvetica Neue';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path4166" />
+      <path
+         d="m 396.33778,348.74015 0,4.1625 4.1625,0 0,-4.1625 -4.1625,0 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:37.5px;font-family:'Helvetica Neue';-inkscape-font-specification:'Helvetica Neue';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path4168" />
+    </g>
+  </g>
+</svg>

--- a/domains/misc/https-everywhere.badssl.com.conf
+++ b/domains/misc/https-everywhere.badssl.com.conf
@@ -1,0 +1,19 @@
+server {
+  listen 80;
+  server_name https-everywhere.badssl.com;
+
+  include /var/www/badssl/common/common.conf;
+
+  root /var/www/badssl/domains/misc/https-everywhere.badssl.com-http;
+}
+
+server {
+  listen 443;
+  server_name https-everywhere.badssl.com;
+
+  include /var/www/badssl/nginx-includes/wildcard.normal.conf;
+  include /var/www/badssl/nginx-includes/tls-defaults.conf;
+  include /var/www/badssl/common/common.conf;
+
+  root /var/www/badssl/domains/misc/https-everywhere.badssl.com-https;
+}


### PR DESCRIPTION
I tried my luck to close https://github.com/lgarron/badssl.com/issues/80

Please test it and also note that https://github.com/EFForg/https-everywhere/pull/3111 has to be merged first and a HTTPS-E version including the new ruleset has to be published to make this work.
After this has been done we should replace  the `[unknown]` placeholder with the version of HTTPS-E released.