### PR TITLE
Add testing hosts for hosts file

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,42 @@ Stock Ubuntu VM, DNS A records for `badssl.com.` and `*.badssl.com.` pointing to
 `badssl.com` is maintained for *manual* testing of security UI in web clients.
 
 The functionality of any given subdomain is likely to be stable, but note that anything may change without notice. If you would like a documented guarantee for a particular use case, please file an issue. (Alternatively, you could make a fork and host your own copy.)
+
+## Testing
+
+If you are working with a test deployment you may find it convienent to add the following items to your `/etc/hosts` file:
+
+```
+# Badssl - List may not be complete.
+127.0.0.1      badssl.com
+127.0.0.1      www.badssl.com
+127.0.0.1      expired.badssl.com
+127.0.0.1      wrong.host.badssl.com
+127.0.0.1      self-signed.badssl.com
+127.0.0.1      incomplete-chain.badssl.com
+127.0.0.1      sha1.badssl.com
+127.0.0.1      mixed.badssl.com
+127.0.0.1      rc4.badssl.com
+127.0.0.1      cbc.badssl.com
+127.0.0.1      hsts.badssl.com
+127.0.0.1      preloaded-hsts.badssl.com
+127.0.0.1      sha1-2016.badssl.com
+127.0.0.1      sha1-2017.badssl.com
+127.0.0.1      broken-diffie-hellman.badssl.com
+127.0.0.1      weak-diffie-hellman.badssl.com
+127.0.0.1      rsa512.badssl.com
+127.0.0.1      rsa1024.badssl.com
+127.0.0.1      rsa8192.badssl.com
+127.0.0.1      ecc.badssl.com
+127.0.0.1      sha256.badssl.com
+127.0.0.1      dh480.badssl.com
+127.0.0.1      dh512.badssl.com
+127.0.0.1      dh1024.badssl.com
+127.0.0.1      dh2048.badssl.com
+127.0.0.1      http.badssl.com
+127.0.0.1      dh-small-subgroup.com
+127.0.0.1      dh-composite.badssl.com
+127.0.0.1      mozilla-modern.badssl.com
+127.0.0.1      mozilla-intermediate.badssl.com
+127.0.0.1      mozilla-old.badssl.com
+```


### PR DESCRIPTION
Adds a partial list of hosts for an `/etc/hosts` file for people who are developing on `badssl` and need to test a local server. I got this from @marumari 