### PR TITLE
Hopefully fix all the jekyll issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,6 @@ keys:
 install-keys:
 	mkdir -p /etc/keys
 	cp ./_site/certs/**/*.key /etc/keys
-	cp ./_site/certs/**/*.pem ./_site/certs/
-	mkdir -p ./_site/common/certs # Jekyll doesn't copy empty directories.
-	cp ./_site/certs/**/*.pem ./_site/common/certs/
 
 .PHONY: link
 link:
@@ -38,8 +35,9 @@ install: keys install-keys link
 
 .PHONY: jekyll
 jekyll:
-	rm -rf ./_site/
 	DOMAIN="${SITE}" HTTP_DOMAIN="http.${SITE}" jekyll build
+	ln -s ../certs _site/common/certs # Create symlink to certs directory
+	./_site/certs/cert-generator/cert-self-signed-symlink-generator.sh # Generate symlinks to self-signed for everything that doesn't exist in certs
 
 .PHONY: docker
 docker: jekyll

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,8 @@ keys:
 install-keys:
 	mkdir -p /etc/keys
 	cp ./_site/certs/**/*.key /etc/keys
+	chmod 640 /etc/keys/*.key
+	chmod 750 /etc/keys
 
 .PHONY: link
 link:

--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,5 @@
 # `domain` and `http-domain` are populated via environment.
 
 # Build settings
+keep_files: ["certs/self-signed"]
 markdown: kramdown

--- a/certs/cert-generator/cert-self-signed-symlink-generator.sh
+++ b/certs/cert-generator/cert-self-signed-symlink-generator.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# Defense is the best offense
+set -eu
+cd "$(dirname ${0})"
+cd ..
+
+# Quit if the symlinks or files are already here
+if [[ -f wildcard.normal.pem ]]; then
+  echo "hmm"
+  exit
+fi
+
+# Let's go up a directory and create all the symlinks downwards
+for i in `ls self-signed`; do
+  ln -s self-signed/$i $i
+done


### PR DESCRIPTION
- Instead of copying all the certs from certs into common/certs, it just creates a symlink
- If a file doesn't exist in the certs directory (but it does in self-signed), it will create a symlink into self-signed
- Jekyll no longer blows away the created keys

Should fix #133 hopefully!