### PR TITLE
Use a fallback certificate for port 443 to avoid SNI connection false positives. Addresses #146.

### DIFF
--- a/certs/cert-generator/badssl-fallback.conf
+++ b/certs/cert-generator/badssl-fallback.conf
@@ -1,0 +1,24 @@
+---
+---
+[ req ]
+default_bits        = 2048
+default_keyfile     = ../self-signed/badssl.key
+distinguished_name  = req_distinguished_name
+encrypt_key         = no
+prompt              = no
+req_extensions      = req_v3_usr
+
+[ req_distinguished_name ]
+countryName         = US
+stateOrProvinceName = California
+localityName        = San Francisco
+organizationName    = BadSSL Fallback. Unknown subdomain or no SNI.
+commonName          = badssl-fallback-unknown-subdomain-or-no-sni
+
+[ req_v3_usr ]
+basicConstraints = CA:FALSE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+subjectAltName = @alt_names
+
+[ alt_names ]
+DNS.1 = badssl-fallback-unknown-subdomain-or-no-sni

--- a/certs/cert-generator/cert-generator.sh
+++ b/certs/cert-generator/cert-generator.sh
@@ -56,6 +56,13 @@ openssl req -new \
   -config badssl-wildcard.conf
 echo
 
+echo "Generating BadSSL Fallback Certificate Signing Request"
+openssl req -new \
+  -key ../self-signed/badssl.com.key \
+  -out badssl-fallback.csr \
+  -config badssl-fallback.conf
+echo
+
 echo "Signing BadSSL Default Certificate"
 openssl x509 -req -days 730 -sha256 -CAcreateserial \
   -in badssl-wildcard.csr \
@@ -122,6 +129,17 @@ openssl x509 -req -days 730 -sha256 -CAcreateserial \
   -extensions req_v3_usr \
   -out out.pem
 cp out.pem ../self-signed/wildcard.self-signed.pem
+rm out.pem
+echo
+
+echo "Self-signing BadSSL Fallback Certificate"
+openssl x509 -req -days 730 -sha256 -CAcreateserial \
+  -in badssl-fallback.csr \
+  -signkey "../self-signed/badssl.com.key" \
+  -extfile badssl-fallback.conf \
+  -extensions req_v3_usr \
+  -out out.pem
+cp out.pem ../self-signed/wildcard.fallback.pem
 rm out.pem
 echo
 

--- a/domains/misc/badssl.com.conf
+++ b/domains/misc/badssl.com.conf
@@ -15,5 +15,5 @@ server {
   include {{ site.serving-path }}/nginx-includes/tls-defaults.conf;
   include {{ site.serving-path }}/common/common.conf;
 
-  root {{ site.serving-path }}/domains/misc/{{ site.domain }};
+  root {{ site.serving-path }}/domains/misc/badssl.com;
 }

--- a/domains/misc/www.badssl.com.conf
+++ b/domains/misc/www.badssl.com.conf
@@ -1,0 +1,18 @@
+---
+---
+server {
+  listen 80;
+  server_name www.{{ site.domain }};
+  
+  return 301 https://{{ site.domain }}$request_uri;
+}
+
+server {
+  listen 443;
+  server_name www.{{ site.domain }};
+
+  include {{ site.serving-path }}/nginx-includes/wildcard.normal.conf;
+  include {{ site.serving-path }}/nginx-includes/tls-defaults.conf;
+
+  return 301 https://{{ site.domain }}$request_uri;
+}

--- a/fallback.conf
+++ b/fallback.conf
@@ -1,0 +1,23 @@
+---
+---
+
+server {
+  listen 80;
+  server_name *.badssl.com;
+
+  return 302 https://$host$request_uri;
+}
+
+server {
+  listen 443;
+  server_name *.badssl.com;
+
+  include {{ site.serving-path }}/nginx-includes/wildcard.fallback.conf;
+  include {{ site.serving-path }}/nginx-includes/tls-defaults.conf;
+
+  # Uncomment this to drop the connection.
+  # return 444;
+
+  # Respond and give a helpful error.
+  return 421 "If you have received this response, you are using a connection with the badssl.com fallback certificate. This means you are either trying to connect to an unknown subdomain, or your client does not support Server Name Indication (https://en.wikipedia.org/wiki/Server_Name_Indication).";
+}

--- a/nginx-includes/wildcard.fallback.conf
+++ b/nginx-includes/wildcard.fallback.conf
@@ -1,0 +1,6 @@
+---
+---
+
+ssl on;
+ssl_certificate {{ site.serving-path }}/certs/wildcard.fallback.pem;
+ssl_certificate_key /etc/keys/badssl.com.key;

--- a/nginx.conf
+++ b/nginx.conf
@@ -2,24 +2,8 @@
 ---
 server_names_hash_bucket_size 128;
 
-# Fallback behaviour
-server {
-  listen 80;
-  server_name fallback;
+# Specify the fallback behaviour first.
+include {{ site.serving-path }}/fallback.conf;
 
-  return 302 "https://{{ site.domain }}/";
-}
-
-# Fallback behaviour
-server {
-  listen 443;
-  server_name fallback;
-
-  include {{ site.serving-path }}/nginx-includes/wildcard.normal.conf;
-  include {{ site.serving-path }}/nginx-includes/tls-defaults.conf;
-
-  return 302 "https://{{ site.domain }}/";
-}
-
-include {{ site.serving-path }}/domains/misc.conf;
+# Now include the known subdomains.
 include {{ site.serving-path }}/domains/*/*.conf;


### PR DESCRIPTION
@marumari, could you review this band-aid?