### PR TITLE
Add `tls-v1-3` subdomain.

### DIFF
--- a/domains/misc/badssl.com/dashboard/sets.js
+++ b/domains/misc/badssl.com/dashboard/sets.js
@@ -86,6 +86,7 @@ var sets = [
     fail: "no",
     subdomains: [
       {subdomain: "tls-v1-2", port: 1012},
+      {subdomain: "tls-v1-3", port: 1013},
       {subdomain: "sha256"},
       {subdomain: "rsa2048"},
       {subdomain: "ecc256"},

--- a/domains/misc/badssl.com/index.html
+++ b/domains/misc/badssl.com/index.html
@@ -116,6 +116,7 @@
     <a href="https://tls-v1-0.{{ site.domain }}:1010/" class="dubious"><span class="icon"></span>tls-v1-0</a>
     <a href="https://tls-v1-1.{{ site.domain }}:1011/" class="dubious"><span class="icon"></span>tls-v1-1</a>
     <a href="https://tls-v1-2.{{ site.domain }}:1012/" class="good"><span class="icon"></span>tls-v1-2</a>
+    <a href="https://tls-v1-3.{{ site.domain }}:1013/" class="good"><span class="icon"></span>tls-v1-3</a>
   </div>
   <div class="group">
     <h2 id="certificate-transparency"><span class="emoji">🔍</span>Certificate Transparency</h2>

--- a/domains/protocol/tls-v1-3.conf
+++ b/domains/protocol/tls-v1-3.conf
@@ -1,0 +1,29 @@
+---
+---
+server {
+  listen 80;
+  server_name tls-v1-3.{{ site.domain }};
+  
+  return 301 https://$server_name:1013$request_uri;
+}
+
+server {
+  listen 443;
+  server_name tls-v1-3.{{ site.domain }};
+
+  include {{ site.serving-path }}/nginx-includes/wildcard-normal.conf;
+  include {{ site.serving-path }}/nginx-includes/tls-defaults.conf;
+
+  return 301 https://$server_name:1013$request_uri;
+}
+
+server {
+  listen 1013;
+  server_name tls-v1-3.{{ site.domain }};
+
+  include {{ site.serving-path }}/nginx-includes/wildcard-normal.conf;
+  include {{ site.serving-path }}/nginx-includes/tls-v1-3.conf;
+  include {{ site.serving-path }}/common/common.conf;
+
+  root {{ site.serving-path }}/domains/protocol/tls-v1-3;
+}

--- a/domains/protocol/tls-v1-3/index.html
+++ b/domains/protocol/tls-v1-3/index.html
@@ -1,0 +1,12 @@
+---
+subdomain: tls-v1-3
+layout: page
+favicon: green
+background: green
+---
+
+<div id="content">
+  <h1 style="font-size: 12vw;">
+    {{ page.subdomain }}.<br>{{ site.domain }}
+  </h1>
+</div>

--- a/nginx-includes/tls-v1-3.conf
+++ b/nginx-includes/tls-v1-3.conf
@@ -1,0 +1,7 @@
+---
+---
+
+ssl_session_timeout 5m;
+
+ssl_protocols TLSv1.3;
+ssl_ciphers 'TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256';


### PR DESCRIPTION
This adds tls-v1-3 on port 1013, similar to how other protocol subdomains are implemented. Also adds the test to the dashboard.