### PR TITLE
Change all ☠️ defunct from dubious to bad

### DIFF
--- a/domains/misc/badssl.com/index.html
+++ b/domains/misc/badssl.com/index.html
@@ -153,7 +153,7 @@
   </div>
   <div class="group">
     <h2 id="defunct"><span class="emoji">☠️</span>Defunct</h2>
-    <a href="https://sha1-2016.{{ site.domain }}/" class="dubious"><span class="icon"></span>sha1-2016</a>
+    <a href="https://sha1-2016.{{ site.domain }}/" class="bad"><span class="icon"></span>sha1-2016</a>
     <a href="https://sha1-2017.{{ site.domain }}/" class="bad"><span class="icon"></span>sha1-2017</a>
     <a href="https://sha1-intermediate.{{ site.domain }}/" class="bad"><span class="icon"></span>sha1-intermediate</a>
     <a href="https://invalid-expected-sct.{{ site.domain }}/" class="bad"><span class="icon"></span>invalid-expected-sct</a>


### PR DESCRIPTION
All defunct cases should be simply "bad"~~, as they will fall back to some generic cert anyways.~~ _(their respective old certs served now correctly)_

However… Would it make sense to either mention that the subdomains no longer exhibit what was intended in their actual page content too? Maybe by changing from `red`&`orange` to `grey` and updating "expires at" to "expired at"? If there's an agreed upon way of doing so I'd happily update them to show they're now defunct in their text itself too.