### PR TITLE
chore: redirect to the http page to actually check if the protocol update occurs

### DIFF
--- a/domains/misc/badssl.com/index.html
+++ b/domains/misc/badssl.com/index.html
@@ -128,7 +128,7 @@
     <a href="https://preloaded-hsts.{{ site.domain }}/" class="good"><span class="icon"></span>preloaded-hsts</a>
     <a href="https://subdomain.preloaded-hsts.{{ site.domain }}/" class="bad"><span class="icon"></span>subdomain.preloaded-hsts</a>
     <hr>
-    <a href="https://https-everywhere.{{ site.domain }}/" class="good"><span class="icon"></span>https-everywhere</a>
+    <a href="http://https-everywhere.{{ site.domain }}/" class="good"><span class="icon"></span>https-everywhere</a>
   </div>
   <div class="group">
     <h2 id="ui"><span class="emoji">👀</span>UI</h2>


### PR DESCRIPTION
Previously the `https-everywhere` link redirected to [`https://https-everywhere.badssl.com/`](https://https-everywhere.badssl.com/), which would always show the https page, thus not checking for the protocol update. This has been changed to redirect to [`http://https-everywhere.badssl.com/`](http://https-everywhere.badssl.com/), so that a protocol upgrade can actually be observed.