### PR TITLE
Switch mozilla-modern to wildcard-ecc256

### DIFF
--- a/domains/cipher-suite/mozilla-modern.conf
+++ b/domains/cipher-suite/mozilla-modern.conf
@@ -11,7 +11,7 @@ server {
   listen 443;
   server_name mozilla-modern.{{ site.domain }};
 
-  include {{ site.serving-path }}/nginx-includes/wildcard-normal.conf;
+  include {{ site.serving-path }}/nginx-includes/wildcard-ecc256.conf;
   include {{ site.serving-path }}/nginx-includes/tls-mozilla-modern.conf;
   include {{ site.serving-path }}/common/common.conf;
 


### PR DESCRIPTION
Current https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility asks for ECDSA only, so switching from `wildcard-normal.conf` to `wildcard-ecc256.conf` seems to match it better.

I'm not making any additional #483 changes for now, to not interfere with @christhompson's work on 6f64093 (that looks great! and addresses many other updates), so this is just to complement the nginx/VM updates underway that also include major bumps of the mozilla-* configs.