### PR TITLE
fix: correct grammar in rsa2048 page

### DIFF
--- a/domains/cert/rsa2048/index.html
+++ b/domains/cert/rsa2048/index.html
@@ -12,5 +12,5 @@ background: green
 </div>
 
 <div id="footer" style="font-size: 2.75vw;">
-  This site uses an 2048-bit RSA key for key exchange.
+  This site uses a 2048-bit RSA key for key exchange.
 </div>


### PR DESCRIPTION
## Description

This PR fixes a grammatical error in the RSA 2048 page.

## Changes Made

- Changed "an 2048-bit" to "a 2048-bit" in the footer text

## Issue

The article "an" is used before words starting with a vowel sound. Since "2048" starts with a consonant sound ("two"), the correct article is "a".

**Before:** "This site uses an 2048-bit RSA key for key exchange."  
**After:** "This site uses a 2048-bit RSA key for key exchange."

Fixes #550

---

💰 **Tips appreciated!** If this PR helps, consider sending USDT (TRC20) to:  
`TJL2uq9nC6aqqGTDSUaUg8KWepSh8htrft`