### PR TITLE
fix: Spelling error in the RSA 2048 page

### DIFF
--- a/domains/cert/rsa2048/index.html
+++ b/domains/cert/rsa2048/index.html
@@ -12,5 +12,5 @@ background: green
 </div>
 
 <div id="footer" style="font-size: 2.75vw;">
-  This site uses an 2048-bit RSA key for key exchange.
+  This site uses a 2048-bit RSA key for key exchange.
 </div>


### PR DESCRIPTION
Fixes #550

Corrects a grammatical error in `domains/cert/rsa2048/index.html` where the article "an" was incorrectly used before "2048-bit". The footer text now reads "a 2048-bit RSA key" instead of "an 2048-bit RSA key".